### PR TITLE
fix(dockerfile): add GIT strategy to avoid diverged branches (RDT-787)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,10 +81,11 @@ You can do this by commenting out specific lines in the python script within the
     #     return
     ```
 
-2. **Repository Name Placeholder**: For testing purposes, you might need to simulate actions against a specific repository's data. Comment out the line fetching the repository's full name to avoid conflicts or errors during this phase.
+2. **Repository Name Placeholder**: For testing purposes, you might need to simulate actions against a specific repository's data. Comment out the line fetching the repository's full name to avoid conflicts or errors during this phase. Instead, replace it with a known testing repository, like this:
 
-    ```py
-    # repo_fullname = event['repository']['full_name']  # Comment out for testing
+    ```python
+    # repo_fullname = event['repository']['full_name']        # Comment out for testing
+    repo_fullname = 'app-frameworks/actions-internal-test'    # Add this for testing
     ```
 
 By commenting out these lines, you'll be able to run your tests in a more controlled and isolated manner, simulating different conditions without affecting the actual repository or workflow.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # especially in CI environments like GitHub Actions, where Git commands are run in the `/github/workspace`.
 # Without this configuration, Git might refuse to operate in the workspace directory due to security policies.
 RUN git config --system --add safe.directory /github/workspace
+RUN git config --global pull.ff only
 
 COPY sync_pr_to_gitlab/github_pr_to_internal_pr.py /
 

--- a/sync_pr_to_gitlab/github_pr_to_internal_pr.py
+++ b/sync_pr_to_gitlab/github_pr_to_internal_pr.py
@@ -188,7 +188,6 @@ def main():
     pr_commit_id = pr_check_approver(pr_creator, pr_comments_url, pr_approve_labeller)
 
     repo_fullname = event['repository']['full_name']
-    repo_fullname = 'app-frameworks/actions-internal-test'
 
     pr_num = event['pull_request']['number']
     pr_head_branch = 'contrib/github_pr_' + str(pr_num)


### PR DESCRIPTION
This GH actions fails, when there are divergent branches and Git doesn't know how to reconcile them (`git pull` command) ... local branch and the remote branch have diverged, meaning there are different commits on each branch that are not present on the other

```sh
Connecting to GitLab...
Adding and fetching the internal remote...
  File "/github_pr_to_internal_pr.py", line 253, in <module>
    main()
  File "/github_pr_to_internal_pr.py", line 211, in main
    gl = setup_project(repo_fullname, pr_base_branch)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/github_pr_to_internal_pr.py", line 69, in setup_project
    git.pull(GITLAB_REMOTE, pr_base_branch)
  File "/usr/local/lib/python3.11/site-packages/git/cmd.py", line 800, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/git/cmd.py", line 1386, in _call_process
    return self.execute(call, **exec_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/git/cmd.py", line 1[18](https://github.com/espressif/esp-iot-solution/actions/runs/9186281214/job/25263321369#step:4:19)3, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git pull gitlab master
  stderr: 'From ***/app-frameworks/actions-internal-test
 * branch            master     -> FETCH_HEAD
 * [new branch]      master     -> gitlab/master
hint: You have divergent branches and need to specify how to reconcile them.
hint: You can do so by running one of the following commands sometime before
hint: your next pull:
hint: 
hint:   git config pull.rebase false  # merge
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint: 
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
fatal: Need to specify how to reconcile divergent branches.'
```

## Spotted in 
- https://github.com/espressif/esp-iot-solution/actions/runs/9186281214/job/25263321369

## Changes
- In this PR we are adding default GIT strategy set to FastForward only
- removed forgotten testing code causing rewriting repo name

## Related
- internal JIRA ticket RDT-786