### PR TITLE
Allow other Gitlab namespaces than the default "espressif" (RDT-805)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ jobs:
           GIT_CONFIG_NAME: ${{ secrets.GIT_CONFIG_NAME }}
           GIT_CONFIG_EMAIL: ${{ secrets.GIT_CONFIG_EMAIL }}
           JIRA_PROJECT: SOMEPROJECT
+          GITLAB_NAMESPACE: SOMENAMESPACE  # This is optional (defaults to 'espressif' if not present)
 ```
 
 ### Environment Variables and Secrets Configuration
@@ -70,14 +71,15 @@ The GitHub PR to GitLab MR Sync workflow requires configuring specific environme
 
 Below is a detailed table outlining the necessary configurations:
 
-| Variable/Secret    | Description                                                               | Requirement |
-| ------------------ | ------------------------------------------------------------------------- | ----------- |
-| `GITHUB_TOKEN`     | Automatically provided by GitHub to authorize actions.                    | Inherited   |
-| `GITLAB_URL`       | URL of the Espressif GitLab instance for API requests.                    | Mandatory   |
-| `GITLAB_TOKEN`     | Access token for creating MRs, comments, and updates in Espressif GitLab. | Mandatory   |
-| `GIT_CONFIG_NAME`  | Username for Git commits when syncing, usually a bot name.                | Mandatory   |
-| `GIT_CONFIG_EMAIL` | Email for Git commits when syncing, representing the bot email.           | Mandatory   |
-| `JIRA_PROJECT`     | The slug of the JIRA project where new issues will be created.            | Mandatory   |
+| Variable/Secret    | Description                                                                | Requirement |
+| ------------------ | -------------------------------------------------------------------------- | ----------- |
+| `GITHUB_TOKEN`     | Automatically provided by GitHub to authorize actions.                     | Inherited   |
+| `GITLAB_URL`       | URL of the Espressif GitLab instance for API requests.                     | Mandatory   |
+| `GITLAB_TOKEN`     | Access token for creating MRs, comments, and updates in Espressif GitLab.  | Mandatory   |
+| `GIT_CONFIG_NAME`  | Username for Git commits when syncing, usually a bot name.                 | Mandatory   |
+| `GIT_CONFIG_EMAIL` | Email for Git commits when syncing, representing the bot email.            | Mandatory   |
+| `JIRA_PROJECT`     | The slug of the JIRA project where new issues will be created.             | Mandatory   |
+| `GITLAB_NAMESPACE` | Namespace in GitLab where the project is located. Defaults to 'espressif'. | Optional    |
 
 ## Steps to Sync a PR (by user)
 

--- a/sync_pr_to_gitlab/github_pr_to_internal_pr.py
+++ b/sync_pr_to_gitlab/github_pr_to_internal_pr.py
@@ -17,6 +17,7 @@ from gitlab.exceptions import GitlabGetError
 GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 GITLAB_URL = os.environ['GITLAB_URL']
 GITLAB_TOKEN = os.environ['GITLAB_TOKEN']
+GITLAB_NAMESPACE = os.environ.get('GITLAB_NAMESPACE', 'espressif')
 
 GITHUB_REMOTE = 'origin'
 GITLAB_REMOTE = 'gitlab'
@@ -60,7 +61,8 @@ def setup_project(repo_fullname, pr_base_branch):
     print('Connecting to GitLab...')
     gl = gitlab.Gitlab(url=GITLAB_URL, private_token=GITLAB_TOKEN)
     gl.auth()
-    gl_project_url = f'{GITLAB_URL[:URL_HDR_LEN]}{GITLAB_TOKEN}:{GITLAB_TOKEN}@{GITLAB_URL[URL_HDR_LEN:]}/{repo_fullname}.git'
+    project_name = repo_fullname.split('/')[-1]
+    gl_project_url = f'{GITLAB_URL[:URL_HDR_LEN]}{GITLAB_TOKEN}:{GITLAB_TOKEN}@{GITLAB_URL[URL_HDR_LEN:]}/{GITLAB_NAMESPACE}/{project_name}.git'
 
     git = Git('.')
 
@@ -208,7 +210,7 @@ def main():
 
     # Gitlab setup and cloning internal codebase
     gl = setup_project(repo_fullname, pr_base_branch)
-    project_gl = gl.projects.get(repo_fullname)
+    project_gl = gl.projects.get(f'{GITLAB_NAMESPACE}/{repo_fullname.split("/")[-1]}')
 
     if pr_label == LABEL_REBASE:
         sync_pr(pr_num, pr_head_branch, pr_commit_id, project_gl, pr_base_branch, pr_html_url, rebase_flag=True)


### PR DESCRIPTION
This PR should solve the problem when a GitHub project mirror originates from a different GitLab namespace than `espressif`.

For example, in the case of:
- Source GitLab project: `https://<internal_gitlab_server>/ae_group/esp-iot-solution`
- Target GitHub mirror: `https://github.com/espressif/esp-iot-solution`

the current implementation of this GitHub Action tries to resolve the source project as `https://<internal_gitlab_server>/espressif/esp-iot-solution`, which doesn't exist.

We are adding a new optional variable `GITLAB_NAMESPACE` to overcome this problem:

```yaml
jobs:
  sync_prs_to_internal_codebase:
    steps:
      ...
      - name: Sync approved PRs to internal codebase
        uses: espressif/sync-pr-to-gitlab@v1
        env:
          ...
          GITLAB_NAMESPACE: SOMENAMESPACE  # This is optional (defaults to 'espressif' if not present)
```

Without `GITLAB_NAMESPACE` set:
- the action will default to using the `espressif` namespace in GitLab.
- it will work as before without any changes (shouldn't be breaking change to existing implementations of this GH action)

With `GITLAB_NAMESPACE` set:
- the action will use the value of `GITLAB_NAMESPACE` to construct the path for the GitLab repository.
- this allows for specifying a different namespace as needed.
- by making `GITLAB_NAMESPACE` optional and defaulting to `espressif` when not set, the action maintains backward compatibility while providing additional flexibility.

## Related
- Closes internal JIRA ticket RDT-805
