### PR TITLE
fix: remove hardcoded Python path (RDT-1412)

### DIFF
--- a/sync_pr_to_gitlab/github_pr_to_internal_pr.py
+++ b/sync_pr_to_gitlab/github_pr_to_internal_pr.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 
 import gitlab
 import requests
@@ -152,7 +153,7 @@ def notify_maintainers(pr_head_branch, pr_base_branch, project_gl, mr_iid):
 
     codeowners_list = []
     for file in modified_files:
-        cmd = f'/usr/bin/python3 {CODEOWNERS_CHECK_PATH} identify {file}'
+        cmd = f'{sys.executable} {CODEOWNERS_CHECK_PATH} identify {file}'
         try:
             output = subprocess.check_output(cmd, shell=True, text=True, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
## Description

Adjust hardcoded Python paths to use `sys.executable`.

The original code hardcoded the Python path as `/usr/bin/python3`, but this file may not exist in the Alpine image pulled from Docker Hub, causing execution issues in some CI pipelines. To avoid problems associated with hardcoded paths, use `sys.executable` instead of the hardcoded Python path.

## Related

- https://github.com/docker-library/docs/blob/master/python/content.md#multiple-python-versions-in-the-image - Explanation of Python Docker Image regarding `/usr/bin/python`
- https://github.com/espressif/esp-iot-solution/actions/runs/15577866467/job/43868929284?pr=527 - Example of a failing CI run due to this issue

## Testing

Performed some simple tests in Docker containers.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
