### PR TITLE
feat: allow sync without `JIRA_PROJECT` and fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_stages: [pre-commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace # Removes trailing whitespaces from lines
       - id: end-of-file-fixer # Ensures files end with a newline
@@ -18,36 +18,36 @@ repos:
       - id: double-quote-string-fixer # Converts double quotes to single quotes in strings
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.15.12
     hooks:
       - id: ruff                                         # Linter
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format                                  # Formatter (replaces Black)
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.12.0
+    rev: v3.16.0
     hooks:
       - id: reorder-python-imports # Reorders Python imports to a standard format (replaces isort)
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v2.0.0
     hooks:
       - id: mypy # Runs mypy for Python type checking
-        additional_dependencies: ['types-all']
+        additional_dependencies: [types-requests]
 
   - repo: https://github.com/espressif/conventional-precommit-linter
-    rev: v1.6.0
+    rev: v1.11.0
     hooks:
       - id: conventional-precommit-linter # Lints commit messages for conventional format
         stages: [commit-msg]
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: v3.1.0
+    rev: v4.0.5
     hooks:
       - id: pylint # Runs pylint on Python code
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.2
     hooks:
       - id: codespell # Code spell checker
         args: ["--write-changes"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: check-executables-have-shebangs # Checks executables have a proper shebang
       - id: mixed-line-ending # Detects mixed line endings (CRLF/LF)
         args: ['-f=lf'] # Forces files to use LF line endings
-      - id: double-quote-string-fixer # Converts single quotes to double quotes in strings
+      - id: double-quote-string-fixer # Converts double quotes to single quotes in strings
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.4

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ jobs:
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
           GIT_CONFIG_NAME: ${{ secrets.GIT_CONFIG_NAME }}
           GIT_CONFIG_EMAIL: ${{ secrets.GIT_CONFIG_EMAIL }}
-          JIRA_PROJECT: SOMEPROJECT
-          GITLAB_NAMESPACE: SOMENAMESPACE  # This is optional (defaults to 'espressif' if not present)
+          JIRA_PROJECT: SOMEPROJECT  # Optional: adds "Closes <JIRA>" for PR titles containing SOMEPROJECT-<number>
+          GITLAB_NAMESPACE: SOMENAMESPACE  # Optional: defaults to 'espressif' if not present
 ```
 
 ### Environment Variables and Secrets Configuration
@@ -78,7 +78,7 @@ Below is a detailed table outlining the necessary configurations:
 | `GITLAB_TOKEN`     | Access token for creating MRs, comments, and updates in Espressif GitLab.  | Mandatory   |
 | `GIT_CONFIG_NAME`  | Username for Git commits when syncing, usually a bot name.                 | Mandatory   |
 | `GIT_CONFIG_EMAIL` | Email for Git commits when syncing, representing the bot email.            | Mandatory   |
-| `JIRA_PROJECT`     | The slug of the JIRA project where new issues will be created.             | Mandatory   |
+| `JIRA_PROJECT`     | Jira project slug; used to close the related Jira ticket if set.           | Optional    |
 | `GITLAB_NAMESPACE` | Namespace in GitLab where the project is located. Defaults to 'espressif'. | Optional    |
 
 ## Steps to Sync a PR (by user)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,12 @@
 [tool.ruff]
     exclude        = ["^venv/"]      # Paths to ignore during linting
     line-length    = 160             # Specifies the maximum line length for ruff checks
-    lint.select    = ['E', 'F', 'W'] # Types of issues ruff should check for
     target-version = "py311"         # Specifies the target Python version for ruff checks
 
     [tool.ruff.format] # See formatter config options at https://docs.astral.sh/ruff/formatter
         quote-style = "single"
+    [tool.ruff.lint]
+        select = ['E', 'F', 'W'] # Types of issues ruff should check for
 
 [tool.mypy]
     disallow_incomplete_defs = false    # Disallows defining functions with incomplete type annotations
@@ -95,7 +96,7 @@
     version_provider         = "scm"
 
     [tool.commitizen.customize]
-        bump_map = { "change" = "MINOR", "feat" = "MINOR", "fix" = "PATCH", "refactor" = "PATCH", "remove" = "PATCH", "revert" = "PATCH" }
+        bump_map = { change = "MINOR", feat = "MINOR", fix = "PATCH", refactor = "PATCH", remove = "PATCH", revert = "PATCH" }
         bump_pattern = "^(change|feat|fix|refactor|remove|revert)"
         change_type_order = [
             "change",

--- a/sync_pr_to_gitlab/github_pr_to_internal_pr.py
+++ b/sync_pr_to_gitlab/github_pr_to_internal_pr.py
@@ -213,9 +213,22 @@ def main():
 
     # Getting the PR title and body
     pr_title = event['pull_request']['title']
-    idx = pr_title.find(os.environ['JIRA_PROJECT'])  # Finding the JIRA issue tag
-    pr_title_desc = pr_title[0 : idx - 2] + ' (GitHub PR)'
-    pr_jira_issue = pr_title[idx:-1]
+    jira_project = os.environ.get('JIRA_PROJECT')
+    pr_jira_issue = None
+    pr_title_desc = pr_title + ' (GitHub PR)'
+    if jira_project:
+        jira_issue_pattern = re.compile(r'(?<![A-Za-z0-9_-])' + re.escape(jira_project) + r'-\d+(?![A-Za-z0-9_-])')
+        jira_match = jira_issue_pattern.search(pr_title)
+        if jira_match:
+            pr_jira_issue = jira_match.group(0)
+            pr_title_without_jira = re.sub(
+                r'\s*[\[(]?\s*' + re.escape(pr_jira_issue) + r'\s*[\])]?\s*',
+                ' ',
+                pr_title,
+                count=1,
+            )
+            pr_title_without_jira = re.sub(r'\s{2,}', ' ', pr_title_without_jira).strip()
+            pr_title_desc = (pr_title_without_jira or pr_title) + ' (GitHub PR)'
     pr_body = str(event['pull_request']['body'])
 
     # Gitlab setup and cloning internal codebase
@@ -246,7 +259,8 @@ def main():
 
     print('Updating merge request description...')
     mr_desc = '## Description \n' + pr_body + '\n ##### (Add more info here)' + '\n## Related'
-    mr_desc += '\n* Closes ' + pr_jira_issue
+    if pr_jira_issue:
+        mr_desc += '\n* Closes ' + pr_jira_issue
     mr_desc += '\n* Merges ' + pr_html_url
     if is_esp_idf:
         mr_desc += (

--- a/sync_pr_to_gitlab/github_pr_to_internal_pr.py
+++ b/sync_pr_to_gitlab/github_pr_to_internal_pr.py
@@ -43,8 +43,9 @@ def pr_check_approver(pr_creator, pr_comments_url, pr_approve_labeller, esp_idf_
         comment_body = comment['body']
 
         if (
-            bool(re.match('sha=', comment_body, re.I)) and comment['user']['login'] == pr_approve_labeller
-            and (esp_idf_flow is False or pr_approve_labeller != pr_creator) # allow to be creator and approver the same person in non-esp-idf flow
+            bool(re.match('sha=', comment_body, re.I))
+            and comment['user']['login'] == pr_approve_labeller
+            and (esp_idf_flow is False or pr_approve_labeller != pr_creator)  # allow to be creator and approver the same person in non-esp-idf flow
         ):
             return comment_body[4:]
 
@@ -110,7 +111,9 @@ def update_mr(pr_num, pr_head_branch, pr_commit_id, project_gl):
 
 
 # Merge PRs with/without Rebase
-def sync_pr(pr_num, pr_head_branch, pr_commit_id, project_gl, pr_base_branch, pr_html_url, rebase_flag):  # pylint: disable=too-many-arguments
+def sync_pr(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    pr_num, pr_head_branch, pr_commit_id, project_gl, pr_base_branch, pr_html_url, rebase_flag
+):
     try:
         project_gl.branches.get(pr_head_branch)
     except GitlabGetError:
@@ -180,7 +183,7 @@ def main():
 
     if GITLAB_NAMESPACE == DEFAULT_GITLAB_NAMESPACE:
         github_repo_namespace = os.environ['GITHUB_REPOSITORY'].split('/')[0]
-        if  github_repo_namespace != DEFAULT_GITLAB_NAMESPACE:
+        if github_repo_namespace != DEFAULT_GITLAB_NAMESPACE:
             print(f'Cannot sync {github_repo_namespace} namespace repo to {DEFAULT_GITLAB_NAMESPACE} GitLab repo!')
             return
 
@@ -264,7 +267,9 @@ def main():
     mr_desc += '\n* Merges ' + pr_html_url
     if is_esp_idf:
         mr_desc += (
-            '\n## Release notes (Mandatory)\n* [component/development area] <Please update release notes, do NOT remove GitHub PR pointer> (' + pr_html_url + ')'
+            '\n## Release notes (Mandatory)\n* [component/development area] <Please update release notes, do NOT remove GitHub PR pointer> ('
+            + pr_html_url
+            + ')'
         )
 
     mr.description = mr_desc


### PR DESCRIPTION
## Description

This PR updates the sync workflow so it can run without the `JIRA_PROJECT` environment variable.

**Background:** <br />
we have several subprojects whose current workflow is not tracked through Jira. In addition, some newer projects are using new internal tools and platforms, and we do not plan to create dedicated Jira projects for them either. Because of that, requiring `JIRA_PROJECT` blocks adoption of this sync tool in those repositories.

**Changes in this PR:**
- make `JIRA_PROJECT` optional in the sync flow
- skip Jira-related MR title/description handling when `JIRA_PROJECT` is not configured
- fix the current pre-commit setup by updating hook and lint-related configuration

## Related

No related issue.

## Testing

~~Not tested.~~

~~I wasn't able to point the test sandbox to the version from this PR, so end-to-end verification has not been completed yet.~~

Tested in https://github.com/espressif/esp-claw/actions/runs/25722992930

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
